### PR TITLE
prefer composable haskellPackages.extend

### DIFF
--- a/nix/backend/default.nix
+++ b/nix/backend/default.nix
@@ -1,8 +1,6 @@
 { haskell }:
 # Build a new overlay with our own packages
-haskell.packages.ghc802.override {
-  overrides = self: super: {
-    todobackend-common = self.callPackage ./todobackend-common.nix {};
-    todobackend-scotty = self.callPackage ./todobackend-scotty.nix {};
-  };
-}
+haskell.packages.ghc802.extend (self: super: {
+  todobackend-common = self.callPackage ./todobackend-common.nix {};
+  todobackend-scotty = self.callPackage ./todobackend-scotty.nix {};
+})


### PR DESCRIPTION
I think we should discourage the use of the current overriding solution, because it does not behave nicely. Calling override for a second time replaces the old overrides, so it's better to use extend, which you can call as often as you want to build your haskell packages incrementally.

It's not required to use it here, but people may run into this problem when they start building on this example.